### PR TITLE
사이드메뉴 드롭다운 클릭 시 Link 실행 방지

### DIFF
--- a/sofa/src/components/Dropdown/Dropdown.css
+++ b/sofa/src/components/Dropdown/Dropdown.css
@@ -159,7 +159,7 @@
   color:white;
   padding: 0; padding-inline: 0.5rem;
   background:transparent;
-  border-color: transparent;
+  /* border-color: transparent; */
 }
 .dropdown.dropdown-folder-edit .dropdown-header-icon{color:white;}
 .dropdown.dropdown-folder-edit .dropdown-menu{

--- a/sofa/src/components/Dropdown/Dropdown.js
+++ b/sofa/src/components/Dropdown/Dropdown.js
@@ -49,7 +49,10 @@ const Dropdown = ({
       ref={dropdownRef}
       onMouseEnter={() => setIsHovered(true)} // hover 시작
       onMouseLeave={() => setIsHovered(false)} // hover 종료
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+      }}
     >
       <div
         className={`dropdown-header ${isOpen ? "open" : ""}`}


### PR DESCRIPTION
### 제목

- [기능/버그 수정] 간단한 설명

### 본문

1. **설명**: 변경 사항에 대한 자세한 설명
2. **이슈 번호**: 관련된 이슈 번호 (#이슈번호)
3. **변경 사항**:
    - Dropdown.js 전체 div에 이벤트 실행 일시 중지 코드 추가
    - <div
      className={`dropdown ${className}`}
      ref={dropdownRef}
      onMouseEnter={() => setIsHovered(true)} // hover 시작
      onMouseLeave={() => setIsHovered(false)} // hover 종료
      onClick={(e) => {
        e.stopPropagation();
        e.preventDefault();
      }}
    >
4. **테스트 방법**: 변경 사항을 테스트하는 방법
5. **기타**: 추가적으로 필요한 정보 (예: 스크린샷, 관련 문서 링크)
